### PR TITLE
Allow for custom content in header title if specified

### DIFF
--- a/app/views/layouts/moj_internal_template.html.erb
+++ b/app/views/layouts/moj_internal_template.html.erb
@@ -73,7 +73,7 @@
             </div>
           </div>
           <div class="header-app-name">
-            <%= config_item(:app_title) %>
+            <%= content_for?(:header_app_name) ? yield(:header_app_name) : config_item(:app_title) %>
           </div>
           <div id="log-in-out">
             <%= yield :log_in_out %>


### PR DESCRIPTION
Hi all, as a part of [this](https://trello.com/c/qe7OxYhM) card I need to be able to make the main title in the layout a link.

As discussed with @cfq (who said I should also ping @threedaymonk), this change will allow you to define any content you like there rather than turn it into a link in all cases. I've made the change so that existing users of this template shouldn't need to change anything (I think).

Any feedback appreciated.