### PR TITLE
Removing top of page block

### DIFF
--- a/app/views/layouts/moj_internal_template.html.erb
+++ b/app/views/layouts/moj_internal_template.html.erb
@@ -1,4 +1,3 @@
-<%= yield :top_of_page %>
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="lte-ie8" lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" <%= yield(:html_attributes) %>><![endif]-->
 <!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>" <%= yield(:html_attributes) %>><!--<![endif]-->


### PR DESCRIPTION
Because nobody should use it. 

Plus, IE11 doesn't like it.
